### PR TITLE
Update for use with Rails 6.0.6.X

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -119,7 +119,7 @@ There are a handful of exciting new additions in version 1.0 of <tt>vestal_versi
       @user.update_attribute(:first_name, "Stephen")
       @user.first_name = "Steve"
       @user.save
-      @user.update_attributes(:last_name => "Jobs")
+      @user.update(:last_name => "Jobs")
     end
     @user.version # => 1
 
@@ -154,12 +154,12 @@ There are a handful of exciting new additions in version 1.0 of <tt>vestal_versi
 
 * Storing which user is responsible for a revision. Rather than introduce a lot of controller magic to guess what to store, you can simply update an additional attribute on your versioned model: <tt>updated_by</tt>.
 
-    @user.update_attributes(:last_name => "Jobs", :updated_by => "Tyler")
+    @user.update(:last_name => "Jobs", :updated_by => "Tyler")
     @user.versions.last.user # => "Tyler"
 
   Instead of passing a simple string to the <tt>updated_by</tt> setter, you can pass a model instance, such as an ActiveRecord user or administrator. The association will be saved polymorphically alongside the version.
 
-    @user.update_attributes(:last_name => "Jobs", :updated_by => current_user)
+    @user.update(:last_name => "Jobs", :updated_by => current_user)
     @user.versions.last.user # => #<User first_name: "Steven", last_name: "Tyler">
 
 * Global configuration. The new <tt>vestal_versions</tt> Rails generator also writes an initializer with instructions on how to set application-wide options for the <tt>versioned</tt> method.

--- a/lib/vestal_versions.rb
+++ b/lib/vestal_versions.rb
@@ -120,7 +120,7 @@ module VestalVersions
       include Deletion
 
       prepare_versioned_options(options)
-      has_many :versions, lambda { order(Arel.sql("#{table_name}.#{connection.quote_column_name('number')}")) }, options, &block
+      has_many :versions, lambda { order(Arel.sql("#{table_name}.#{connection.quote_column_name('number')}")) }, **options, &block
     end
   end
 end

--- a/lib/vestal_versions/control.rb
+++ b/lib/vestal_versions/control.rb
@@ -55,7 +55,7 @@ module VestalVersions
     #   user = User.find_by_first_name("Steve")
     #   user.version # => 1
     #   user.merge_version do
-    #     user.update_attributes(:first_name => "Steven", :last_name => "Tyler")
+    #     user.update(:first_name => "Steven", :last_name => "Tyler")
     #     user.update_attribute(:first_name, "Stephen")
     #     user.update_attribute(:last_name, "Richert")
     #   end

--- a/spec/vestal_versions/deletion_spec.rb
+++ b/spec/vestal_versions/deletion_spec.rb
@@ -7,6 +7,7 @@ describe VestalVersions::Deletion do
   context "a deleted version's changes" do
 
     before do
+      ActiveRecord.yaml_column_permitted_classes = [Symbol, Time] if ActiveRecord::VERSION::MAJOR > 6
       subject.update_attribute(:last_name, 'Jobs')
     end
 
@@ -30,6 +31,7 @@ describe VestalVersions::Deletion do
   context "deleted versions" do
     let(:last_version){ VestalVersions::Version.last }
     before do
+      ActiveRecord.yaml_column_permitted_classes = [Symbol, Time] if ActiveRecord::VERSION::MAJOR > 6
       subject.update_attribute(:last_name, 'Jobs')
       subject.destroy
     end
@@ -60,7 +62,7 @@ describe VestalVersions::Deletion do
 
       it "restores even if the schema has changed" do
         new_mods = last_version.modifications.merge(:old_column => 'old')
-        last_version.update_attributes(:modifications => new_mods)
+        last_version.update(:modifications => new_mods)
 
         last_version.restore.should == subject
       end

--- a/spec/vestal_versions/reversion_spec.rb
+++ b/spec/vestal_versions/reversion_spec.rb
@@ -73,7 +73,7 @@ describe VestalVersions::Reversion do
 
   it "does not store the reverted_from for subsequent saves" do
     subject.revert_to!(1)
-    subject.update_attributes(:name => 'Bill Gates')
+    subject.update(:name => 'Bill Gates')
     subject.versions.last.reverted_from.should be_nil
   end
 
@@ -88,14 +88,14 @@ describe VestalVersions::Reversion do
     subject.revert_to(1)
     subject.name = "Reverted"
     subject.save
-    subject.update_attributes(:name => 'Bill Gates')
+    subject.update(:name => 'Bill Gates')
     subject.versions.last.reverted_from.should be_nil
   end
 
   it "clears the reverted_from if the model is reloaded after a revert_to without a save" do
     subject.revert_to(1)
     subject.reload
-    subject.update_attributes(:name => 'Bill Gates')
+    subject.update(:name => 'Bill Gates')
 
     subject.versions.last.reverted_from.should be_nil
   end

--- a/spec/vestal_versions/users_spec.rb
+++ b/spec/vestal_versions/users_spec.rb
@@ -5,17 +5,17 @@ describe VestalVersions::Users do
   let(:user){ User.create(:name => 'Steve Richert') }
 
   it 'defaults to nil' do
-    user.update_attributes(:first_name => 'Stephen')
+    user.update(:first_name => 'Stephen')
     user.versions.last.user.should be_nil
   end
 
   it 'accepts and returns an ActiveRecord user' do
-    user.update_attributes(:first_name => 'Stephen', :updated_by => updated_by)
+    user.update(:first_name => 'Stephen', :updated_by => updated_by)
     user.versions.last.user.should == updated_by
   end
 
   it 'accepts and returns a string user name' do
-    user.update_attributes(:first_name => 'Stephen', :updated_by => updated_by.name)
+    user.update(:first_name => 'Stephen', :updated_by => updated_by.name)
     user.versions.last.user.should == updated_by.name
   end
 end

--- a/spec/vestal_versions/version_spec.rb
+++ b/spec/vestal_versions/version_spec.rb
@@ -55,7 +55,7 @@ describe VestalVersions::Versions do
   it "return the original version if it is a double revert" do
     user.revert_to!(2)
     version = user.version
-    user.update_attributes(:last_name => 'Gates')
+    user.update(:last_name => 'Gates')
     user.revert_to!(version)
     user.versions.last.original_number.should == 2
   end


### PR DESCRIPTION
The main change here is to `lib/vestal_versions.rb` - changing key args to hash args to prevent a arity ArgumentError.

```
in `has_many': wrong number of arguments (given 3, expected 1..2) (ArgumentError)
```

The rest of the changes are non-functional changes to tests (and documentation) necessary to see specs pass in modern Rails versions.
